### PR TITLE
API support for Subject Alternative Name (SAN) extensions 

### DIFF
--- a/include/certifier/property.h
+++ b/include/certifier/property.h
@@ -58,11 +58,6 @@ typedef enum CERTIFIER_OPT
      */
         CERTIFIER_OPT_OPTIONS = 14,
         CERTIFIER_OPT_ECC_CURVE_ID = 15,
-
-        /**
-     * Set this to request certificates with an X.509 subjectAltName (otherName type).
-     * @note value type: string
-     */
         CERTIFIER_OPT_SYSTEM_ID = 16,
         CERTIFIER_OPT_FABRIC_ID = 17,
         CERTIFIER_OPT_PRODUCT_ID = 18,
@@ -77,7 +72,14 @@ typedef enum CERTIFIER_OPT
         CERTIFIER_OPT_INPUT_NODE = 27,
         CERTIFIER_OPT_NODE_ID = 28,
         CERTIFIER_OPT_AUTH_TAG_1 = 29,
-        // 30 - 36 are unused
+        /**
+     * Set these enums (30-32) to request certificates with X.509 subjectAltNames (otherName types).
+     * @note value type: string
+     */
+        CERTIFIER_OPT_DNS_SAN = 30,
+        CERTIFIER_OPT_IP_SAN = 31,
+        CERTIFIER_OPT_EMAIL_SAN = 32,
+        // 33 - 36 are unused
         CERTIFIER_OPT_LOG_MAX_SIZE = 37,
         // 38,39 are unused
         // 40 - 43 are unused

--- a/include/certifier/xpki_client.h
+++ b/include/certifier/xpki_client.h
@@ -96,8 +96,12 @@ typedef enum
  *  Mac Address (Mandatory only on RDK Devices).
  *  @var get_cert_param_t::serial_number
  *  Serial Number (Optional).
- *  @var get_cert_param_t::san
- *  SAN (Optional).
+ *  @var get_cert_param_t::dns_san
+ *  DNS Name added to Subject Alternate Name (SAN) field (Optional).
+ *  @var get_cert_param_t::ip_san
+ *  IP Address added to Subject Alternate Name (SAN) field (Optional).
+ *  @var get_cert_param_t::email_san
+ *  Email Address added to Subject Alternate Name (SAN) field (Optional).
  *  @var get_cert_param_t::common_name
  *  Contains the CN value field of the Certificate Subject. (Optional)
  */
@@ -120,10 +124,12 @@ typedef struct
     uint64_t node_id;
     uint64_t fabric_id;
     uint32_t case_auth_tag;
-    // additonal parameters
+    // optional parameters below
     const char * mac_address;
     const char * serial_number;
-    const char * san;
+    const char * dns_san;
+    const char * ip_san;
+    const char * email_san;
     const char * common_name;
 } get_cert_param_t;
 

--- a/src/certifier.c
+++ b/src/certifier.c
@@ -1293,6 +1293,9 @@ char* certifier_create_csr_post_data(CertifierPropMap *props,
     const char *system_id = property_get(props, CERTIFIER_OPT_SYSTEM_ID);
     const char *fabric_id = property_get(props, CERTIFIER_OPT_FABRIC_ID);
     const char *mac_address = property_get(props, CERTIFIER_OPT_MAC_ADDRESS);
+    const char *dns_san = property_get(props, CERTIFIER_OPT_DNS_SAN);
+    const char *ip_san = property_get(props, CERTIFIER_OPT_IP_SAN);
+    const char *email_san = property_get(props, CERTIFIER_OPT_EMAIL_SAN);
     const char *profile_name = property_get(props, CERTIFIER_OPT_PROFILE_NAME);
     const char *product_id = property_get(props, CERTIFIER_OPT_PRODUCT_ID);
     const char *authenticated_tag_1 = property_get(props, CERTIFIER_OPT_AUTH_TAG_1);
@@ -1339,6 +1342,24 @@ char* certifier_create_csr_post_data(CertifierPropMap *props,
     if (util_is_not_empty(mac_address)) {
         log_debug("\nmacAddress Id :\n%s\n", mac_address);
         json_object_set_string(root_object, "macAddress", mac_address);
+    }
+
+    if (util_is_not_empty(dns_san)) {
+        log_debug("\ndnsNames Id :\n%s\n", dns_san);
+        json_object_dotset_value(root_object, "dnsNames",
+                         json_parse_string(dns_san));
+    }
+
+    if (util_is_not_empty(ip_san)) {
+        log_debug("\nipAddress Id :\n%s\n", ip_san);
+        json_object_dotset_value(root_object, "ipAddresses",
+                         json_parse_string(ip_san));
+    }
+
+    if (util_is_not_empty(email_san)) {
+        log_debug("\nemails Id :\n%s\n", email_san);
+        json_object_dotset_value(root_object, "emails",
+                         json_parse_string(email_san));
     }
 
     if (num_days > 0) {

--- a/src/property.c
+++ b/src/property.c
@@ -145,6 +145,9 @@ struct _PropMap {
     char *product_id;
     char *auth_tag_1;
     char *mac_address;
+    char *dns_san;
+    char *ip_san;
+    char *email_san;
     char *crt;
     char *profile_name;
     char *source;
@@ -371,6 +374,18 @@ property_set(CertifierPropMap *prop_map, CERTIFIER_OPT name, const void *value) 
         SV(prop_map->mac_address, value);
             break;
 
+        case CERTIFIER_OPT_DNS_SAN:
+        SV(prop_map->dns_san, value);
+            break;
+
+        case CERTIFIER_OPT_IP_SAN:
+        SV(prop_map->ip_san, value);
+            break;
+
+        case CERTIFIER_OPT_EMAIL_SAN:
+        SV(prop_map->email_san, value);
+            break;
+
         case CERTIFIER_OPT_SIMULATION_CERT_EXP_DATE_BEFORE:
         SV(prop_map->simulated_cert_expiration_date_before, value);
             break;
@@ -558,6 +573,18 @@ property_get(CertifierPropMap *prop_map, CERTIFIER_OPT name) {
 
         case CERTIFIER_OPT_MAC_ADDRESS:
             retval = prop_map->mac_address;
+            break;
+
+        case CERTIFIER_OPT_DNS_SAN:
+            retval = prop_map->dns_san;
+            break;
+
+        case CERTIFIER_OPT_IP_SAN:
+            retval = prop_map->ip_san;
+            break;
+
+        case CERTIFIER_OPT_EMAIL_SAN:
+            retval = prop_map->email_san;
             break;
 
         case CERTIFIER_OPT_SIMULATION_CERT_EXP_DATE_BEFORE:
@@ -1105,6 +1132,9 @@ static void free_prop_map_values(CertifierPropMap *prop_map) {
     FV(prop_map->product_id);
     FV(prop_map->auth_tag_1);
     FV(prop_map->mac_address);
+    FV(prop_map->dns_san);
+    FV(prop_map->ip_san);
+    FV(prop_map->email_san);
     FV(prop_map->crt);
     FV(prop_map->profile_name);
     FV(prop_map->ecc_curve_id);

--- a/src/xpki_client.c
+++ b/src/xpki_client.c
@@ -191,6 +191,9 @@ XPKI_CLIENT_ERROR_CODE xc_get_default_cert_param(get_cert_param_t * params)
 
     params->keypair       = NULL;
     params->mac_address   = NULL;
+    params->dns_san       = NULL;
+    params->ip_san        = NULL;
+    params->email_san     = NULL;
     params->serial_number = NULL;
     params->crt           = NULL;
     params->source_id     = NULL;
@@ -336,6 +339,18 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
         snprintf(system_id, SYSTEM_ID_SIZE, "%s:%s", params->mac_address, params->serial_number);
         system_id[SYSTEM_ID_SIZE - 1] = '\0';
         ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_SYSTEM_ID, system_id));
+    }
+    if (params->dns_san != NULL)
+    {
+        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_DNS_SAN, params->dns_san));
+    }
+    if (params->ip_san != NULL)
+    {
+        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_IP_SAN, params->ip_san));
+    }
+    if (params->email_san != NULL)
+    {
+        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_EMAIL_SAN, params->email_san));
     }
     if (params->crt == NULL)
     {

--- a/tests/xc_apis/xc_api_tests.c
+++ b/tests/xc_apis/xc_api_tests.c
@@ -60,6 +60,9 @@ static void test_get_cert()
 
     params.output_p12_path = "output-xc-test-san.p12";
     params.profile_name    = "XFN_DL_PAI_1_Class_3";
+    params.dns_san         = "[\"dns-test.matter.opensource.com\"]";
+    params.ip_san          = "[\"1.2.3.4\"]";
+    params.email_san       = "[\"testemail@test.com\"]";
     params.serial_number   = "ABCD22";
     params.lite            = false;
     error                  = xc_get_cert(&params);


### PR DESCRIPTION
API support for Subject Alternative Name (SAN) extensions when requesting certificates.

Updated unit tests for supported SANs (dns, ip, email).