### PR TITLE
Fix test builds for mocka and unity tests

### DIFF
--- a/tests/easy_api_tests.c
+++ b/tests/easy_api_tests.c
@@ -60,7 +60,7 @@ static void _check_version(const char * version, const int line)
 
 static void test_api_easy(void ** state)
 {
-    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_KEYSTORE, "/tmp/fake.p12");
+    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_INPUT_P12_PATH, "/tmp/fake.p12");
     certifier_api_easy_set_mode(easy, CERTIFIER_MODE_GET_CERT_STATUS);
 
     int rc = certifier_api_easy_perform(easy);
@@ -95,7 +95,7 @@ static inline void _check_crt(const char * b64_token, const char * type, const i
 static void test_api_easy_create_tokens(void ** state)
 {
     certifier_api_easy_set_mode(easy, CERTIFIER_MODE_CREATE_CRT);
-    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_CRT_TYPE, "CRT_TYPE_1");
+    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_AUTH_TYPE, "CRT_TYPE_1");
     int rc = certifier_api_easy_perform(easy);
     ASSERT_TRUE_MESSAGE(rc != 0, "CRT created with no token!");
 
@@ -106,13 +106,13 @@ static void test_api_easy_create_tokens(void ** state)
     check_crt(certifier_api_easy_get_result(easy), "CRT_TYPE_1");
 
     certifier_api_easy_set_mode(easy, CERTIFIER_MODE_CREATE_CRT);
-    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_CRT_TYPE, "CRT_TYPE_2");
+    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_AUTH_TYPE, "CRT_TYPE_2");
     rc = certifier_api_easy_perform(easy);
     assert_int_equal(0, rc);
     check_crt(certifier_api_easy_get_result(easy), "CRT_TYPE_2");
 
     certifier_api_easy_set_mode(easy, CERTIFIER_MODE_CREATE_CRT);
-    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_CRT_TYPE, "CRT_TYPE_3");
+    certifier_api_easy_set_opt(easy, CERTIFIER_OPT_AUTH_TYPE, "CRT_TYPE_3");
     rc = certifier_api_easy_perform(easy);
     assert_int_equal(0, rc);
     check_crt(certifier_api_easy_get_result(easy), "CRT_TYPE_3");

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -163,9 +163,9 @@ static void test_certifier_client_requests(void ** state)
     certifier_set_property(certifier, CERTIFIER_OPT_PROFILE_NAME, profile_name);
     certifier_set_property(certifier, CERTIFIER_OPT_PRODUCT_ID, product_id);
 
-    int options = certifier_get_property(certifier, CERTIFIER_OPT_OPTIONS);
+    int options = (int)(uintptr_t)certifier_get_property(certifier, CERTIFIER_OPT_OPTIONS);
     options |= CERTIFIER_OPT_CERTIFICATE_LITE;
-    certifier_set_property(certifier, CERTIFIER_OPT_OPTIONS, options);
+    certifier_set_property(certifier, CERTIFIER_OPT_OPTIONS, (const void*)(uintptr_t)options);
 
     CertifierError rc = certifierclient_request_x509_certificate(_certifier_get_properties(certifier), (unsigned char *) csr,
                                                                  node_address, certifier_id, &ret);
@@ -207,11 +207,11 @@ static void test_certifier_client_requests1(void ** state)
     return_code = certifier_set_property(certifier, CERTIFIER_OPT_CN_PREFIX, "xcal.tv");
     assert_int_equal(0, return_code);
 
-    return_code = certifier_set_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS, 730);
+    return_code = certifier_set_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS, (const void*)(uintptr_t)730);
     assert_int_equal(0, return_code);
 
     cn_prefix = certifier_get_property(certifier, CERTIFIER_OPT_CN_PREFIX);
-    num_days  = certifier_get_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS);
+    num_days  = (unsigned int)(uintptr_t)certifier_get_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS);
     assert_int_equal(730, num_days);
     if (cn_prefix)
     {
@@ -253,9 +253,9 @@ static void test_certifier_client_requests1(void ** state)
     certifier_set_property(certifier, CERTIFIER_OPT_PROFILE_NAME, profile_name);
     certifier_set_property(certifier, CERTIFIER_OPT_PRODUCT_ID, product_id);
 
-    int options = certifier_get_property(certifier, CERTIFIER_OPT_OPTIONS);
+    int options = (int)(uintptr_t)certifier_get_property(certifier, CERTIFIER_OPT_OPTIONS);
     options |= CERTIFIER_OPT_CERTIFICATE_LITE;
-    certifier_set_property(certifier, CERTIFIER_OPT_OPTIONS, options);
+    certifier_set_property(certifier, CERTIFIER_OPT_OPTIONS, (const void*)(uintptr_t)options);
 
     CertifierError rc = certifierclient_request_x509_certificate(_certifier_get_properties(certifier), (unsigned char *) csr,
                                                                  cn_prefix, ledger_id, &ret);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -196,7 +196,7 @@ static void test_certifier_client_requests1(void ** state)
     const char * source        = "test_libledger";
     char * ret                 = NULL;
     char * cn_prefix           = NULL;
-    int icount = 0, return_code = 0;
+    int return_code = 0;
     unsigned int num_days = 0;
 
     JSON_Value * root_value   = json_value_init_object();
@@ -1172,7 +1172,6 @@ static void test_pkcs12(void ** state)
     XFILE pkcs12_file       = NULL;
     X509_LIST * certs       = NULL;
     ECC_KEY * key           = NULL;
-    ECC_KEY * dup_key       = NULL;
     X509_CERT * cert        = NULL;
     char * certifier_id     = NULL;
     char * generated_crt    = NULL;
@@ -1182,11 +1181,7 @@ static void test_pkcs12(void ** state)
     int der_key_len         = 0;
     int ret                 = 0;
 
-    char * tmp_crt = NULL;
-
     int rc               = 0;
-    const char * expires = "0";
-    const char * action  = "allow";
     certifier_set_property(certifier, CERTIFIER_OPT_OUTPUT_NODE, "dummy output node");
 
     blob_len = base64_decode(pkcs12_blob, pkcs12_blob_base64);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1517,40 +1517,40 @@ int main(int argc, char ** argv)
 
     if ((argc == 2) && (XSTRNCMP(argv[1], "--performance", XSTRLEN(argv[1])) == 0))
     {
-        RUN_TEST(test_sha256_ripemd_b58_performance);
+        RUN_TEST((UnityTestFunction)test_sha256_ripemd_b58_performance);
     }
     else
     {
         printf("starting base64 test \n");
-        RUN_TEST(test_base64);
+        RUN_TEST((UnityTestFunction)test_base64);
         printf("ending base64 test \n");
         printf("starting base58 test \n");
-        RUN_TEST(test_base58);
+        RUN_TEST((UnityTestFunction)test_base58);
         printf("ending base58 test \n");
         printf("starting test_file_utils test \n");
-        RUN_TEST(test_file_utils);
+        RUN_TEST((UnityTestFunction)test_file_utils);
         printf("ending test_file_utils test \n");
         fflush(stdout);
-        RUN_TEST(test_random_val);
-        RUN_TEST(test_str_utils);
-        RUN_TEST(test_set_curl_error);
-        RUN_TEST(test_sha256_ripemd_b58);
-        RUN_TEST(test_ecc_key);
-        RUN_TEST(test_verify_signature_1);
-        RUN_TEST(test_verify_signature_2);
-        RUN_TEST(test_x509_cert);
+        RUN_TEST((UnityTestFunction)test_random_val);
+        RUN_TEST((UnityTestFunction)test_str_utils);
+        RUN_TEST((UnityTestFunction)test_set_curl_error);
+        RUN_TEST((UnityTestFunction)test_sha256_ripemd_b58);
+        RUN_TEST((UnityTestFunction)test_ecc_key);
+        RUN_TEST((UnityTestFunction)test_verify_signature_1);
+        RUN_TEST((UnityTestFunction)test_verify_signature_2);
+        RUN_TEST((UnityTestFunction)test_x509_cert);
 
-        RUN_TEST(test_pkcs12);
+        RUN_TEST((UnityTestFunction)test_pkcs12);
 
-        RUN_TEST(test_certifier_client_requests);
-        RUN_TEST(test_certifier_client_requests1);
-        RUN_TEST(test_certifier_create_crt1);
-        RUN_TEST(test_certifier_create_node_address);
-        RUN_TEST(test_certifier_get_version);
+        RUN_TEST((UnityTestFunction)test_certifier_client_requests);
+        RUN_TEST((UnityTestFunction)test_certifier_client_requests1);
+        RUN_TEST((UnityTestFunction)test_certifier_create_crt1);
+        RUN_TEST((UnityTestFunction)test_certifier_create_node_address);
+        RUN_TEST((UnityTestFunction)test_certifier_get_version);
 
-        RUN_TEST(test_logging);
+        RUN_TEST((UnityTestFunction)test_logging);
 
-        RUN_TEST(test_options);
+        RUN_TEST((UnityTestFunction)test_options);
     }
     return UNITY_END();
 #endif


### PR DESCRIPTION
**Problem:**
Both of the following commands were resulting in errors:
```shell
cmake ../.. -DENABLE_CMAKE_VERBOSE_MAKEFILE=ON -DENABLE_CMOCKA=ON -DENABLE_MBEDTLS=OFF -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
```
```shell
cmake ../.. -DENABLE_CMAKE_VERBOSE_MAKEFILE=ON -DENABLE_CMOCKA=OFF -DENABLE_MBEDTLS=OFF -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
```
These were mostly casting errors, unused variables, and incomplete update of enum values

The errors are described in each commit that fixes it.

**Question:**
Casting of (UnityTestFunction) in RUN_TEST invocation instead of inside the macro might be ugly, but allows the compiler to catch everytime the `int(*)(void**)` type function is used, so we can make sure the `void**` variable is not used before adding the cast.
Do you suggest a better way to do this? Maybe inside a new macro?
