### PR TITLE
Feature/opt2

### DIFF
--- a/include/certifier/property.h
+++ b/include/certifier/property.h
@@ -182,11 +182,21 @@ typedef enum CERTIFIER_OPT
     CERTIFIER_OPT_AUTORENEW_CERTS_PATH_LIST,
 
     /**
-     * @brief returns the certificate ID of the new certificate
+     * @brief if non NULL, an allocated X509_CERT certificate will be
+     * placed here
      *
-     * @note value type: char[20]
+     * @note value type: X509_CERT *
      */
-    CERTIFIER_OPT_OUTPUT_CERT_ID,
+    CERTIFIER_OPT_CERT_X509_OUT,
+
+    /**
+     * @brief optional fields to set mTLS certificate (P12)
+     * and its password
+     *
+     * @note value type: string
+     */
+    CERTIFIER_OPT_MTLS_P12_PATH,
+    CERTIFIER_OPT_MTLS_P12_PASSWORD,
 
 } CERTIFIER_OPT;
 

--- a/include/certifier/property.h
+++ b/include/certifier/property.h
@@ -181,6 +181,13 @@ typedef enum CERTIFIER_OPT
      */
     CERTIFIER_OPT_AUTORENEW_CERTS_PATH_LIST,
 
+    /**
+     * @brief returns the certificate ID of the new certificate
+     *
+     * @note value type: char[20]
+     */
+    CERTIFIER_OPT_OUTPUT_CERT_ID,
+
 } CERTIFIER_OPT;
 
 typedef enum

--- a/include/certifier/xpki_client.h
+++ b/include/certifier/xpki_client.h
@@ -113,6 +113,12 @@ typedef enum
  *  Contains the CN value field of the Certificate Subject (Optional).
  *  @var get_cert_param_t::domain
  *  Contains the domain of the CN value field of the Certificate Subject (Optional).
+ *  @var get_cert_param_t::cert_x509_out
+ *  Contains the generated X.509 certificate (Optional)
+ *  @var get_cert_param_t::mtls_p12_path
+ *  Contains the path to the mTLS certificate (P12) (Optional).
+ *  @var get_cert_param_t::mtls_p12_password
+ *  Contains the password for the mTLS certificate (P12) (Optional).
  */
 typedef struct
 {
@@ -143,8 +149,9 @@ typedef struct
     const char * email_san;
     const char * common_name;
     const char * domain;
-    /* Certificate ID (sha1 hash) of the new certificate */
-    void** cert_id_out;
+    X509_CERT  * cert_x509_out;
+    const char * mtls_p12_path;
+    const char * mtls_p12_password;
 } get_cert_param_t;
 
 /** @struct get_cert_status_param_t

--- a/include/certifier/xpki_client.h
+++ b/include/certifier/xpki_client.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #define CERTIFIER_STATIC_URL "https://cert-static.xpki.io/v1/certifier"
-#define DEFAULT_CERTIFER_URL "https://certifier.xpki.io/v1/certifier"
+#define DEFAULT_CERTIFIER_URL "https://certifier.xpki.io/v1/certifier"
 
 typedef enum
 {
@@ -143,6 +143,8 @@ typedef struct
     const char * email_san;
     const char * common_name;
     const char * domain;
+    /* Certificate ID (sha1 hash) of the new certificate */
+    void** cert_id_out;
 } get_cert_param_t;
 
 /** @struct get_cert_status_param_t

--- a/internal_headers/certifier/certifier_internal.h
+++ b/internal_headers/certifier/certifier_internal.h
@@ -56,7 +56,7 @@ CertifierPropMap * _certifier_get_properties(Certifier * certifier);
 /**
  * Set the x509 certificate
  * @param certifier
- * @param der_cert
+ * @param der_cert - address of x509 certificate (will be freed)
  * @note for unit testing only!
  */
 void _certifier_set_x509_cert(Certifier * certifier, const X509_CERT * cert);

--- a/src/certifier_api_easy.c
+++ b/src/certifier_api_easy.c
@@ -882,6 +882,9 @@ static int process_command_line(CERTIFIER * easy)
         case 'w':
             return_code = certifier_set_property(easy->certifier, CERTIFIER_OPT_OUTPUT_P12_PASSWORD, optarg);
             break;
+        case 'Q':
+            return_code = certifier_set_property(easy->certifier, CERTIFIER_OPT_MTLS_P12_PASSWORD, optarg);
+            break;
         case 'L':
             return_code = certifier_set_property(easy->certifier, CERTIFIER_OPT_CFG_FILENAME, optarg);
             break;
@@ -925,6 +928,14 @@ static int process_command_line(CERTIFIER * easy)
                 break;
             }
             return_code = certifier_set_property(easy->certifier, CERTIFIER_OPT_OUTPUT_P12_PATH, optarg);
+
+            break;
+        case 'q':
+            if (optarg == NULL)
+            {
+                break;
+            }
+            return_code = certifier_set_property(easy->certifier, CERTIFIER_OPT_MTLS_P12_PATH, optarg);
 
             break;
         case 'P':

--- a/src/http.c
+++ b/src/http.c
@@ -31,6 +31,8 @@ static void set_curl_options(CURL * curl, CertifierPropMap * prop_map)
     int is_trace_http_enabled = property_is_option_set(prop_map, CERTIFIER_OPTION_TRACE_HTTP);
     long http_timeout         = (long) property_get(prop_map, CERTIFIER_OPT_HTTP_TIMEOUT);
     long http_connect_timeout = (long) property_get(prop_map, CERTIFIER_OPT_HTTP_CONNECT_TIMEOUT);
+    char * mtls_p12           = property_get(prop_map, CERTIFIER_OPT_MTLS_P12_PATH);
+    char * mtls_password      = property_get(prop_map, CERTIFIER_OPT_MTLS_P12_PASSWORD);
 
     log_debug("[set_curl_options] - Host Validation=%i", host_validation);
     log_debug("[set_curl_options] - Peer Validation=%i", peer_validation);
@@ -40,8 +42,19 @@ static void set_curl_options(CURL * curl, CertifierPropMap * prop_map)
     // First set the URL that is about to receive our POST.
     http_set_curlopt(curl, CURLOPT_ACCEPT_ENCODING, "");
     http_set_curlopt(curl, CURLOPT_VERBOSE, is_debug_http_enabled);
-    http_set_curlopt(curl, CURLOPT_CAINFO, property_get(prop_map, CERTIFIER_OPT_CA_INFO));
-    http_set_curlopt(curl, CURLOPT_CAPATH, property_get(prop_map, CERTIFIER_OPT_CA_PATH));
+
+    if ((mtls_p12) && (mtls_password))
+    {
+        http_set_curlopt(curl, CURLOPT_SSLCERT, mtls_p12);
+        http_set_curlopt(curl, CURLOPT_SSLCERTTYPE, "P12");
+        http_set_curlopt(curl, CURLOPT_SSLCERTPASSWD, mtls_password);
+    }
+    else
+    {
+        http_set_curlopt(curl, CURLOPT_CAINFO, property_get(prop_map, CERTIFIER_OPT_CA_INFO));
+        http_set_curlopt(curl, CURLOPT_CAPATH, property_get(prop_map, CERTIFIER_OPT_CA_PATH));
+    }
+
     http_set_curlopt(curl, CURLOPT_SSL_VERIFYHOST, host_validation);
     http_set_curlopt(curl, CURLOPT_SSL_VERIFYPEER, peer_validation);
     http_set_curlopt(curl, CURLOPT_FAILONERROR, 1L);

--- a/src/property.c
+++ b/src/property.c
@@ -44,7 +44,7 @@
 #define DEFAULT_USER_CA_PATH "/usr/local/etc/certfier"
 #define DEFAULT_GLOBAL_CA_PATH "/etc/certifier"
 #define DEFAULT_CURDIR_CA_PATH "."
-#define DEFAULT_CERTIFER_URL "https://certifier.xpki.io/v1/certifier"
+#define DEFAULT_CERTIFIER_URL "https://certifier.xpki.io/v1/certifier"
 #define DEFAULT_PROFILE_NAME "XFN_Matter_OP_Class_3_ICA"
 #define DEFAULT_CERT_MIN_TIME_LEFT_S 90 * 24 * 60 * 60;
 #define DEFAULT_OPT_SOURCE "unset-libcertifier-c-native"
@@ -171,6 +171,7 @@ struct _PropMap
     char * action;
     char * input_node;
     char * autorenew_certs_path_list;
+    void** cert_id_out;
 };
 
 static void free_prop_map_values(CertifierPropMap * prop_map);
@@ -338,6 +339,9 @@ int property_set(CertifierPropMap * prop_map, CERTIFIER_OPT name, const void * v
 
     switch (name)
     {
+    case CERTIFIER_OPT_OUTPUT_CERT_ID:
+        prop_map->cert_id_out = (void**)value;
+        break;
     case CERTIFIER_OPT_CFG_FILENAME:
         SV(prop_map->cfg_filename, value);
         break;
@@ -540,6 +544,10 @@ void * property_get(CertifierPropMap * prop_map, CERTIFIER_OPT name)
     {
     case CERTIFIER_OPT_CFG_FILENAME:
         retval = prop_map->cfg_filename;
+        break;
+
+    case CERTIFIER_OPT_OUTPUT_CERT_ID:
+        retval = prop_map->cert_id_out;
         break;
 
     case CERTIFIER_OPT_AUTH_TYPE:
@@ -776,7 +784,7 @@ int property_set_defaults(CertifierPropMap * prop_map)
 
     if (prop_map->certifier_url == NULL)
     {
-        return_code = property_set(prop_map, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFER_URL);
+        return_code = property_set(prop_map, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFIER_URL);
         if (return_code != 0)
         {
             log_error("Failed to set default property name: CERTIFIER_OPT_CERTIFIER_URL with error code: %i", return_code);

--- a/src/xpki_client.c
+++ b/src/xpki_client.c
@@ -303,7 +303,8 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
                         XPKI_CLIENT_INVALID_ARGUMENT);
 #endif // RDK_BUILD
 
-    char system_id[SYSTEM_ID_SIZE] = { 0 };
+    XPKI_CLIENT_ERROR_CODE err_code = XPKI_CLIENT_ERROR_INTERNAL;
+    char system_id[SYSTEM_ID_SIZE]  = { 0 };
 
     VerifyOrReturnError(xpki_auth_type_to_string(params->auth_type) != NULL, XPKI_CLIENT_INVALID_ARGUMENT);
 
@@ -324,8 +325,6 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
     {
         ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_OUTPUT_P12_PASSWORD, params->output_p12_password));
     }
-
-    ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_OUTPUT_CERT_ID, params->cert_id_out));
 
     ReturnErrorOnFailure(
         certifier_set_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS, (const void *) (size_t) params->validity_days));
@@ -423,7 +422,14 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
         ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_INPUT_P12_PASSWORD, params->output_p12_password));
     }
 
-    return xc_register_certificate(params->keypair);
+    err_code = xc_register_certificate(params->keypair);
+
+    if (err_code == XPKI_CLIENT_SUCCESS)
+    {
+        params->cert_x509_out = (X509_CERT *) certifier_get_property(certifier, CERTIFIER_OPT_CERT_X509_OUT);
+    }
+
+    return err_code;
 }
 
 static XPKI_CLIENT_ERROR_CODE _xc_renew_certificate(XPKI_AUTH_TYPE auth_type)

--- a/src/xpki_client.c
+++ b/src/xpki_client.c
@@ -325,6 +325,8 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
         ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_OUTPUT_P12_PASSWORD, params->output_p12_password));
     }
 
+    ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_OUTPUT_CERT_ID, params->cert_id_out));
+
     ReturnErrorOnFailure(
         certifier_set_property(certifier, CERTIFIER_OPT_VALIDITY_DAYS, (const void *) (size_t) params->validity_days));
     ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFICATE_LITE, (void *) params->lite));
@@ -401,7 +403,13 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
     }
     else
     {
-        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFER_URL));
+        /* Use DEFAULT_CERTIFIER_URL if the certifier.url is not present in the config file. */
+        const char * certifier_url = (char *) certifier_get_property(certifier, CERTIFIER_OPT_CERTIFIER_URL);
+
+        if ((NULL == certifier_url) || (0 == XSTRLEN(certifier_url)))
+        {
+            ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFIER_URL));
+        }
     }
 
     if (certifier_get_property(certifier, CERTIFIER_OPT_OUTPUT_P12_PATH) != NULL)
@@ -457,7 +465,15 @@ XPKI_CLIENT_ERROR_CODE xc_renew_cert(renew_cert_param_t * params)
     }
     else
     {
-        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFER_URL));
+        /**
+         * Use DEFAULT_CERTIFIER_URL if the certifier.url is not present in the config file.
+         */
+        const char * certifier_url = (char *) certifier_get_property(certifier, CERTIFIER_OPT_CERTIFIER_URL);
+
+        if ((NULL == certifier_url) || (0 == XSTRLEN(certifier_url)))
+        {
+            ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFIER_URL));
+        }
     }
     ReturnErrorOnFailure(xc_set_source_id(params->source_id));
     ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_AUTH_TYPE, xpki_auth_type_to_string(params->auth_type)));
@@ -601,7 +617,13 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert_status(get_cert_status_param_t * params, XPKI
     }
     else
     {
-        ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFER_URL));
+        /* Use DEFAULT_CERTIFIER_URL if the certifier.url is not present in the config file. */
+        const char * certifier_url = (char *) certifier_get_property(certifier, CERTIFIER_OPT_CERTIFIER_URL);
+
+        if ((NULL == certifier_url) || (0 == XSTRLEN(certifier_url)))
+        {
+            ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_CERTIFIER_URL, DEFAULT_CERTIFIER_URL));
+        }
     }
 
     return _xc_get_cert_status(status);


### PR DESCRIPTION
1. Added mTLS support.
2. Replaced the file semaphore with a process mutex.
3. Added a feature to return the X.509 certificate in the xc_get_cert() API.
4. Fixed a memory leak and resolved the issue with using the certifier URL in the configuration file.