### PR TITLE
Increasing node address size to store UUID & fixed the issue with product_id

### DIFF
--- a/src/certifier.c
+++ b/src/certifier.c
@@ -45,7 +45,7 @@ static CERTIFIER_LOG_callback logger;
 
 typedef struct Map
 {
-    char node_address[VERY_SMALL_STRING_SIZE];
+    char node_address[SMALL_STRING_SIZE];
     char * base64_public_key;
     unsigned char * der_public_key;
     int der_public_key_len;
@@ -1409,7 +1409,7 @@ CertifierPropMap * certifier_easy_api_get_props(Certifier * certifier)
 
 void certifier_easy_api_get_node_address(Certifier * certifier, char * node_address)
 {
-    memcpy(node_address, certifier->tmp_map.node_address, VERY_SMALL_STRING_SIZE);
+    memcpy(node_address, certifier->tmp_map.node_address, SMALL_STRING_SIZE);
 }
 
 char * certifier_create_csr_post_data(CertifierPropMap * props, const unsigned char * csr, const char * node_address,

--- a/src/certifier_api_easy.c
+++ b/src/certifier_api_easy.c
@@ -35,6 +35,7 @@
 // Defines
 #define DEFAULT_PASSWORD "changeit"
 #define VERY_SMALL_STRING_SIZE 32
+#define SMALL_STRING_SIZE 64
 #define VERY_LARGE_STRING_SIZE 2048
 
 #define PRODUCT_ID_LENGTH 4ul
@@ -1370,7 +1371,7 @@ int certifier_api_easy_create_json_csr(CERTIFIER * easy, unsigned char * csr, ch
     }
     if (!node_address)
     {
-        node_address = XMALLOC(VERY_SMALL_STRING_SIZE);
+        node_address = XMALLOC(SMALL_STRING_SIZE);
         certifier_easy_api_get_node_address(certifier_get_certifier_instance(easy), node_address);
         free_node_address = 1;
     }

--- a/src/xpki_client.c
+++ b/src/xpki_client.c
@@ -344,7 +344,7 @@ XPKI_CLIENT_ERROR_CODE xc_get_cert(get_cert_param_t * params)
     if (params->product_id != 0)
     {
         char product_id[sizeof(uint16_t) * 2 + 1] = { 0 };
-        snprintf(product_id, sizeof(product_id), "%" PRIx16, params->product_id);
+        snprintf(product_id, sizeof(product_id), "%04" PRIx16, params->product_id);
         ReturnErrorOnFailure(certifier_set_property(certifier, CERTIFIER_OPT_PRODUCT_ID, (void *) product_id));
     }
     if (params->fabric_id != 0)


### PR DESCRIPTION
1. Increasing node address size to 64 to store UUID
2. Fixed the issue with leading 0s in matter product_id