### PR TITLE
Fix for USE-SCOPES to reflect in certificate

### DIFF
--- a/include/certifier/property.h
+++ b/include/certifier/property.h
@@ -148,6 +148,11 @@ typedef enum CERTIFIER_OPT
     CERTIFIER_OPT_CERTIFICATE_LITE,
 
     /**
+     * @note value type: bool
+     */
+    CERTIFIER_OPT_USE_SCOPES,
+
+    /**
      * @note value type: string
      */
 
@@ -180,11 +185,6 @@ typedef enum CERTIFIER_OPT
      * @note value type: string
      */
     CERTIFIER_OPT_AUTORENEW_CERTS_PATH_LIST,
-
-    /**
-     * @note value type: bool
-     */
-    CERTIFIER_OPT_USE_SCOPES,
 
     /**
      * @brief if non NULL, an allocated X509_CERT certificate will be

--- a/tests/xc_apis/xc_api_tests.c
+++ b/tests/xc_apis/xc_api_tests.c
@@ -105,12 +105,9 @@ static void  test_get_seed_cert_auth_token()
 
     params.auth_type           = XPKI_AUTH_SAT;
     params.auth_token          = token;
-    params.fabric_id           = 0xABCDABCDABCDABCD;
-    params.node_id             = 0x1234123412341234;
     params.output_p12_password = "newpass";
     params.output_p12_path     = "output-xc-auth-token-test-seed-cert-renewable.p12";
     params.overwrite_p12       = true;
-    params.product_id          = 0xABCD;
     params.profile_name        = "Xfinity_Subscriber_Issuing_ECC_ICA";
     params.validity_days       = 90;
     params.lite                = false;

--- a/tests/xc_apis/xc_api_tests.c
+++ b/tests/xc_apis/xc_api_tests.c
@@ -96,6 +96,33 @@ static void test_get_cert_auth_token()
     TEST_ASSERT_EQUAL_INT(XPKI_CLIENT_SUCCESS, error);
 }
 
+static void  test_get_seed_cert_auth_token()
+{
+    XPKI_CLIENT_ERROR_CODE error;
+    get_cert_param_t params = { 0 };
+
+    xc_get_default_cert_param(&params);
+
+    params.auth_type           = XPKI_AUTH_SAT;
+    params.auth_token          = token;
+    params.fabric_id           = 0xABCDABCDABCDABCD;
+    params.node_id             = 0x1234123412341234;
+    params.output_p12_password = "newpass";
+    params.output_p12_path     = "output-xc-auth-token-test-seed-cert-renewable.p12";
+    params.overwrite_p12       = true;
+    params.product_id          = 0xABCD;
+    params.profile_name        = "Xfinity_Subscriber_Issuing_ECC_ICA";
+    params.validity_days       = 90;
+    params.lite                = false;
+    params.use_scopes          = true;
+    params.common_name         = "X9c0XXBqIosRCg35keK8XsWC2PAdjQrG";
+    params.source_id           = "libcertifier-opensource";
+    params.mac_address         = "00:B0:D0:63:C2:26";
+
+    error = xc_get_cert(&params);
+    TEST_ASSERT_EQUAL_INT(XPKI_CLIENT_SUCCESS, error);
+}
+
 static void test_get_cert_status()
 {
     XPKI_CLIENT_ERROR_CODE error;
@@ -223,6 +250,7 @@ int main(int argc, char ** argv)
     {
         token = argv[1];
         RUN_TEST(test_get_cert_auth_token);
+        RUN_TEST(test_get_seed_cert_auth_token);
         RUN_TEST(test_renew_cert_auth_token);
     }
     RUN_TEST(test_get_cert_status);


### PR DESCRIPTION
Moving CERTIFIER_OPT_USE_SCOPES enum to the right order and added test case to verify seed scope scenario
